### PR TITLE
fix: use inputName instead inputID

### DIFF
--- a/index.js
+++ b/index.js
@@ -777,7 +777,7 @@ class legacyClient {
 				/* Switch to correct input if switching on and legacy service */
 					let inputName = that.inputID;
 					inputName = inputName.replace('/', '%2F');
-					request('http://' + that.ip + ':' + that.webAPIPort + '/goform/formiPhoneAppDirect.xml?SI' + inputID, function(error, response, body) {
+					request('http://' + that.ip + ':' + that.webAPIPort + '/goform/formiPhoneAppDirect.xml?SI' + inputName, function(error, response, body) {
 						if(error) {
 							that.log("Error while switching input %s", error);
 							callback(error);


### PR DESCRIPTION
You forgot to use inputName instead of inputID which leads to the following error:
`
[1/19/2020, 6:31:53 PM] ReferenceError: inputID is not defined
Jan 19 18:31:53 raspberrypi homebridge[1276]:     at Request._callback (/usr/local/lib/node_modules/homebridge-denon-heos/index.js:780:99)
`
I tested the fix on my setup and it worked