### PR TITLE
[2.0.7] Bugfixes in auto-discovery of devices and lost settings after reset

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,3 +5,4 @@
 [2.0.4] Fix for auto detect port if not supported by receiver.
 [2.0.5] Removed some error messages.
 [2.0.6] Fix for bug 2.0.3 
+[2.0.7] Fix for bug in auto-discovery of port settings. Also stable possible to manually set. Fixed bug that the settings of the legacy switches were resetted after resetting homebridge

--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ You can see that it is currently on `SAT/CBL`. This means that you need as input
 }
 ```
 
+## Possible errors
+The following errors can be expected:
+* `Can not access receiver with IP: xx.xx.xx.xx. Might be due to a wrong port. Try 80 or 8080 manually in config file.`
+It is possible that the the software was not able to extract the correct port from the available receivers. Make sure to connect the receivers to the network when (re)starting homebridge. If this doesn't fix the problem, try to set a manual port. 80 is for non-Heos models and 8080 is for Heos models.
+
+* `No Denon receiver with IP: xx.xx.xx.xx found in network. Check Denon network status or try setting a manual port.`
+The specified receiver is not found in the network with the auto-discover function. This means that the auto port set will not work and the device information can not be set in homebridge. If you can control your device, you can ignore this warning. If the plugin is not working. You can try to set a manual port and check if the plugin is working in the home app. Otherwise try checking the network connection of the receiver.
+
+
+
 ## Further Reading and Thanks
 
 Thanks to [nneubauers](https://github.com/nneubauer) for making a stable version that worked with newer Denon models like my AVR x1400. Also thanks to Jer G who took the time to inform me on the volume control of Denon receivers and input settings with special characters.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const platformName = 'DenonAVR';
 
 const infoRetDelay = 250;
 const defaultTrace = true;
-const autoDiscoverTime = 3000;
+const autoDiscoverTime = 5000;
 
 let Service;
 let Characteristic;

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -1,0 +1,154 @@
+const request = require('request');
+const parseString = require('xml2js').parseString;
+const ssdp = require('node-ssdp').Client
+, client = new ssdp({})
+
+class discover {
+	constructor(that, log, foundReceivers, autoDiscoverTime) {
+		this.foundReceivers = foundReceivers;
+		var thisDiv = this;
+
+		client.on('notify', function () {
+			log.error('Got a notification.')
+		})
+		
+		client.on('response', function inResponse(headers, code, rinfo) {
+			let stringData = JSON.stringify(headers, null, '  ');
+			if (stringData.match(/(d|D)enon/)) {
+				let parseData = stringData.match(/"LOCATION": (.*?)(\d+\.\d+\.\d+\.\d+)(.*)/);
+				let temp = parseData[0].split(/"/);
+
+				let ipAddr = temp[3].replace("http://","");
+				let colon = ipAddr.indexOf(":");
+				ipAddr = ipAddr.substring(0,colon);
+
+				let receiver = [];
+
+				receiver.push(ipAddr);
+				receiver.push(temp[3]);
+				if (thisDiv.getIndexIP(ipAddr) == -1)
+				{
+					thisDiv.foundReceivers.push(receiver);
+					thisDiv.retrieveDenonInformation(ipAddr, log);
+					log.debug(ipAddr + ': ' + temp[3]);
+				}
+			}
+		})
+		client.search('upnp:rootdevice')
+
+		/* Stop search client */
+		setTimeout(function () {
+			client.stop()
+			for (let i in that.tvAccessories) {
+				let tempAcces = that.tvAccessories[i]
+				if (!tempAcces.getDevInfoSet()) {
+					if (tempAcces.hasManualPort())
+						log.info('No Denon receiver with IP: %s found in network. Using manual port: %s.', tempAcces.returnIP(), tempAcces.returnPort());
+					else
+						log.error('No Denon receiver with IP: %s found in network. Check Denon network status or try setting a manual port.', tempAcces.returnIP());
+					tempAcces.setDevInfoSet(true);
+				}
+			}
+			for (let i in that.legacyAccessories) {
+				let tempAcces = that.legacyAccessories[i]
+				if (!tempAcces.getDevInfoSet()) {
+					if (tempAcces.hasManualPort())
+						log.info('No Denon receiver with IP: %s found in network. Using manual port: %s.', tempAcces.returnIP(), tempAcces.returnPort());
+					else
+						log.error('No Denon receiver with IP: %s found in network. Check Denon network status or try setting a manual port.', tempAcces.returnIP());
+					tempAcces.setDevInfoSet(true);
+				}
+			}
+		}, autoDiscoverTime)
+	}
+
+	getIndexIP(ipAddr) {
+		for (var i in this.foundReceivers) {
+			if (this.foundReceivers[i].indexOf(ipAddr) != -1)
+				return i;
+		}
+		return -1;
+	}
+
+	getInfoAddress(ipAddr) {
+		for (var i in this.foundReceivers) {
+			if (this.foundReceivers[i][0].indexOf(ipAddr) != -1)
+				return this.foundReceivers[i][1];
+		}
+		return null;
+	}
+
+	retrieveDenonInformation(ipAddr, log) {
+		var index = this.getIndexIP(ipAddr);
+
+		var that = this;
+		request(this.getInfoAddress(ipAddr), function(error, response, body) {
+			if(error) {
+				log.debug("Error while getting information of receiver with IP: %s. %s", that.foundReceivers[index][0], error);
+			} else {
+				body = body.replace(/:/g, '');
+				parseString(body, function (err, result) {
+					if(err) {
+						log.debug("Error while parsing retrieveDenonInformation. %s", err);
+					} else {
+						try {
+							that.foundReceivers[index][3] = result.root.device[0].manufacturer[0];
+							that.foundReceivers[index][4] = (' ' + result.root.device[0].modelName[0]).slice(1);
+							that.foundReceivers[index][5] = result.root.device[0].serialNumber[0];
+							that.foundReceivers[index][2] = result.root.device[0].DMHX_WebAPIPort[0];
+							
+							for (let i = 0; i < result.root.device[0].deviceList[0].device.length; i++){
+								try {
+									that.foundReceivers[index][6] = result.root.device[0].deviceList[0].device[i].firmware_version[0];
+									break;
+								} catch (error) {
+									// log.debug(error);
+								}
+							}
+
+							log('------------------------------');
+							log('Receiver discovered in network:');
+							log('');
+							log('IP Address: %s', that.foundReceivers[index][0]);
+							log('Manufacturer: %s', that.foundReceivers[index][3]);
+							log('Model: %s', that.foundReceivers[index][4]);
+							log('Serialnumber: %s', that.foundReceivers[index][5]);
+							log('Firmware: %s', that.foundReceivers[index][6]);
+							log('Port: %s', that.foundReceivers[index][2]);
+							log('------------------------------');
+						} catch (error) {
+							log.debug('Receiver with IP %s not yet ready.', that.foundReceivers[index][0]);
+							log.debug(error);
+						}
+					}
+				});
+			}
+		});
+	}
+
+	setDenonInformation(that, log) {	
+		let index;
+		if (!that.devInfoSet) {
+			index = this.getIndexIP(that.ip);
+			if (index == -1)
+				return false
+		} else {
+			return true;
+		}
+		
+		that.manufacturer = this.foundReceivers[index][3];
+		that.modelName = this.foundReceivers[index][4];
+		that.serialNumber = this.foundReceivers[index][5];
+		that.firmwareRevision = this.foundReceivers[index][6];
+	
+		if(this.foundReceivers[index][2].includes('80') && !that.usesManualPort)
+			that.webAPIPort = this.foundReceivers[index][2];
+	
+		if(that.webAPIPort.includes('80'))
+			that.devInfoSet = true;
+			
+		return that.devInfoSet;
+	}
+}
+
+module.exports = discover;

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -6,12 +6,12 @@ const ssdp = require('node-ssdp').Client
 class discover {
 	constructor(that, log, foundReceivers, autoDiscoverTime) {
 		this.foundReceivers = foundReceivers;
-		var thisDiv = this;
 
 		client.on('notify', function () {
 			log.error('Got a notification.')
 		})
 		
+		var thisDiv = this;
 		client.on('response', function inResponse(headers, code, rinfo) {
 			let stringData = JSON.stringify(headers, null, '  ');
 			if (stringData.match(/(d|D)enon/)) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "hap-nodejs": ">=0.4.13"
   },
   "dependencies": {
+    "node-ssdp": "^4.0.0",
     "request": ">=2.81.8",
     "xml2js": ">=0.4.19"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-denon-heos",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Denon and possibly Marantz (some are tested with positive results) AVR support for Homebridge: https://github.com/nfarina/homebridge with support for newer version of receiver. This plugin uses the http commands to control the receivers. It is also possible to add a receiver as a tv to your homekit. This way, you can control the receiver with the remote. Set the volume with the remote and change the input, all in one block.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The software searches for devices in the network. If found, it is able to automatically set the port. It is also possible to manually set the port. 
The legacy switches do not lose their settings anymore after a Homebridge reset.